### PR TITLE
fix: Contact List Overlap Page Buttons

### DIFF
--- a/help-hero-front-end/app/src/main/java/com/example/helphero/HomeActivity.java
+++ b/help-hero-front-end/app/src/main/java/com/example/helphero/HomeActivity.java
@@ -183,9 +183,4 @@ public class HomeActivity extends AppCompatActivity {
                 || super.onSupportNavigateUp();
     }
 
-
-    public static rotateAffirmations() {
-
-    }
-
 }

--- a/help-hero-front-end/app/src/main/res/layout/activity_profile.xml
+++ b/help-hero-front-end/app/src/main/res/layout/activity_profile.xml
@@ -21,8 +21,6 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <include layout="@layout/bottom_button_row"/>
-  
     <ScrollView
         android:id="@+id/scroll_view"
         android:layout_width="match_parent"
@@ -30,6 +28,7 @@
         android:layout_marginTop="60dp">
         <LinearLayout
             android:id="@+id/card_linear_layout"
+            android:layout_alignParentBottom="true"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
@@ -385,5 +384,10 @@
 
         </LinearLayout>
     </ScrollView>
+
+    <include
+        layout="@layout/bottom_button_row"
+        android:layout_width="match_parent"
+        android:layout_height="756dp" />
 
 </RelativeLayout>


### PR DESCRIPTION
- Fixed an issue that was causing the list of contacts on the profile page to overlap the navigation buttons on the bottom of the screen when scrolling
-  Related to Github issue #30 