### PR TITLE
impl: Session Changes

### DIFF
--- a/help-hero-front-end/app/src/main/AndroidManifest.xml
+++ b/help-hero-front-end/app/src/main/AndroidManifest.xml
@@ -17,17 +17,18 @@
             android:windowSoftInputMode="stateHidden"
             android:label="@string/app_name"
             android:theme="@style/Theme.HelpHero.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
 
         </activity>
         <activity
             android:name=".SignInActivity"
             android:label="Sign In"
             android:theme="@style/Theme.HelpHero.NoActionBar">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".SignUpActivity"

--- a/help-hero-front-end/app/src/main/java/com/example/helphero/MainActivity.java
+++ b/help-hero-front-end/app/src/main/java/com/example/helphero/MainActivity.java
@@ -20,28 +20,38 @@ import androidx.navigation.ui.NavigationUI;
 
 public class MainActivity extends AppCompatActivity {
 
+    private SharedPreferences sharedPreferences;
+    private String username;
+    private String password;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-
-
-        BottomNavigationView navView = findViewById(R.id.nav_view);
-        // Passing each menu ID as a set of Ids because each
-        // menu should be considered as top level destinations.
-        AppBarConfiguration appBarConfiguration = new AppBarConfiguration.Builder(
-                R.id.navigation_resources, R.id.navigation_home, R.id.navigation_sos,
-                R.id.navigation_profile).build();
-        NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
-        NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
-        NavigationUI.setupWithNavController(navView, navController);
 
         String PREFERENCES = "MyPrefs";
-        SharedPreferences sharedPreferences = getSharedPreferences(PREFERENCES,
-                Context.MODE_PRIVATE);
+        sharedPreferences = getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+        username = sharedPreferences.getString("username","");
+        password = sharedPreferences.getString("password","");
+
+        if(username.equals("")||password.equals(""))
+            startActivity(new Intent(MainActivity.this, SignInActivity.class));
+        else
+        {
+            setContentView(R.layout.activity_main);
+            Toolbar toolbar = findViewById(R.id.toolbar);
+            setSupportActionBar(toolbar);
+
+
+            BottomNavigationView navView = findViewById(R.id.nav_view);
+            // Passing each menu ID as a set of Ids because each
+            // menu should be considered as top level destinations.
+            AppBarConfiguration appBarConfiguration = new AppBarConfiguration.Builder(
+                    R.id.navigation_resources, R.id.navigation_home, R.id.navigation_sos,
+                    R.id.navigation_profile).build();
+            NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
+            NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
+            NavigationUI.setupWithNavController(navView, navController);
+        }
+
     }
 
     @Override
@@ -58,13 +68,17 @@ public class MainActivity extends AppCompatActivity {
 
         //noinspection SimplifiableIfStatement
         if (id == R.id.action_profile) {
+            startActivity(new Intent(MainActivity.this, ProfileFragment.class));
             return true;
         } else if (id == R.id.action_logout) {
             //sends the user back to the sign in page when log out is selected
             //any saved variables will need to be cleared at this step however
             //there is none currently
-            //startActivity(new Intent(MainActivity.this, HomeFragment.class));
-            startActivity(new Intent(MainActivity.this, ProfileFragment.class));
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+            editor.putString("username","");
+            editor.putString("password","");
+            editor.apply();
+            startActivity(new Intent(MainActivity.this, SignInActivity.class));
 
         }
 


### PR DESCRIPTION
- In AndroidManifest.xml, changed starting intent to MainActivity.java to allow user to start at home page if already signed in.
- In MainActivity.java if user is signed in, redirects to home page. If not, redirects to sign in page. When logout button is clicked, username and password are removed from shared preferences and user is taken back to the sign in page.
- These changes are so the user doesn't have to constantly sign in when trying to use app.

Issue #51